### PR TITLE
Change box sizing from initial to content-box to fix issue in IE

### DIFF
--- a/src/component/header.scss
+++ b/src/component/header.scss
@@ -47,7 +47,7 @@ $tablet: 40.0625em;
 	overflow: hidden;
 	font-weight: 700;
 	padding: 2px 15px;
-	box-sizing: initial;
+	box-sizing: content-box;
 	-moz-osx-font-smoothing: grayscale;
 
 	a,
@@ -148,7 +148,7 @@ $tablet: 40.0625em;
 	padding: 0;
 	list-style: none;
 	padding: 0 15px;
-	box-sizing: initial;
+	box-sizing: content-box;
 }
 
 .datahub-header__navigation__item {


### PR DESCRIPTION
IE would not respect `initial` as a value when `border-box` had been set with the `*` selector in the Data Hub reset styles - setting it to `content-box` makes IE respect the value.