### PR TITLE
Amend the Datahub Header blue to a lighter shade

### DIFF
--- a/src/component/header.scss
+++ b/src/component/header.scss
@@ -3,7 +3,7 @@ $govuk-grey-1: #6f777b;
 $govuk-grey-2: #bfc1c3;
 $govuk-grey-3: #dee0e2;
 $govuk-grey-4: #f8f8f8;
-$govuk-blue: #005ea5;
+$govuk-blue: #5694CA;
 $govuk-yellow: #ffbf47;
 
 $tablet: 40.0625em;


### PR DESCRIPTION
As part of the Accessibility work, the shade of blue in the datahub header needed to have a higher contrast figure. The original dark blue was too similar to the black background, so a lighter shade of blue has been picked. 


Here's what the original looks like: 
<img width="229" alt="Screenshot 2020-09-21 at 16 35 31" src="https://user-images.githubusercontent.com/46787754/93787836-8fd1bc80-fc28-11ea-819f-9b6afd6c4be9.png">

And here's what the new shade looks like: 
<img width="328" alt="Screenshot 2020-09-21 at 16 35 17" src="https://user-images.githubusercontent.com/46787754/93788009-9a8c5180-fc28-11ea-9aad-ca7adb7b2f6c.png">

