### PR TITLE
Fix a11y focus

### DIFF
--- a/src/component/header.scss
+++ b/src/component/header.scss
@@ -6,6 +6,7 @@ $govuk-grey-4: #f8f8f8;
 $govuk-blue: #005EA5;
 $govuk-light-blue: #5694CA;
 $govuk-yellow: #ffbf47;
+$govuk-focus: #ffdd01;
 
 $tablet: 40.0625em;
 
@@ -42,20 +43,32 @@ $tablet: 40.0625em;
 	}
 }
 
-@mixin dh-focus() {
-	outline: 3px solid transparent;
-	&:focus {
-		transition: box-shadow 0.1s, outline-color 0.1s 0.1s;
-		box-shadow: 0 0 0 3px $govuk-yellow;
-		outline-offset: 0;
-		outline-color: $govuk-yellow;
+@mixin underline($color: inherit) {
+	position: relative;
+	&::after {
+		content: "";
+		position: absolute;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		border-bottom: 5px solid;
+		border-color: $color;
 	}
 }
 
-@mixin tablet-padding() {
-	@media ( min-width: $tablet ) {
-		padding-left: 30px;
-		padding-right: 30px;
+@mixin focus() {
+	outline: none;
+	// We are increasing specificity here because of color
+	&#{&}:focus {
+		color: $govuk-black;
+		background: $govuk-focus;
+	}
+}
+
+@mixin underline-focus() {
+	@include focus;
+	&:focus {
+		@include underline;
 	}
 }
 
@@ -76,7 +89,7 @@ $tablet: 40.0625em;
 		}
 
 		&__link {
-			@include dh-focus;
+			@include focus;
 		}
 
 		&__text {
@@ -132,7 +145,7 @@ $tablet: 40.0625em;
 		border: 0;
 		color: white;
 		background: 0 0;
-		@include dh-focus;
+		@include focus;
 
 		@media print {
 			font-family: sans-serif;
@@ -218,7 +231,7 @@ $tablet: 40.0625em;
 				display: inline-block;
 				padding: 5px 0;
 				width: 100%;
-				@include dh-focus;
+				@include focus;
 
 				// Is this ever used?
 				&--active {
@@ -283,12 +296,11 @@ $tablet: 40.0625em;
 				}
 
 				&:hover {
-					color: $govuk-blue;
-
+					@media ( max-width: $tablet ) {
+						color: $govuk-blue;
+					}
 					@media ( min-width: $tablet ) {
-						color: $govuk-black;
-						padding-bottom: 3px;
-						border-bottom: 5px solid $govuk-blue;
+						@include underline($govuk-blue);
 					}
 				}
 
@@ -296,8 +308,7 @@ $tablet: 40.0625em;
 					color: $govuk-blue;
 
 					@media ( min-width: $tablet ) {
-						padding-bottom: 3px;
-						border-bottom: 5px solid $govuk-blue;
+						@include underline;
 					}
 
 					&:visited,
@@ -306,7 +317,7 @@ $tablet: 40.0625em;
 					}
 				}
 
-				@include dh-focus;
+				@include underline-focus;
 			}
 		}
 	}
@@ -351,4 +362,3 @@ $tablet: 40.0625em;
 		}
 	}
  }
- 

--- a/src/component/header.scss
+++ b/src/component/header.scss
@@ -33,7 +33,14 @@ $tablet: 40.0625em;
 	// causes content to wrap 1 word per line:
 	// https://medium.com/@jessebeach/beware-smushed-off-screen-accessible-text-5952a4c2cbfe
 	white-space: nowrap iff($important, !important);
- }
+}
+
+@mixin tablet-padding() {
+	@media ( min-width: $tablet ) {
+		padding-left: 30px;
+		padding-right: 30px;
+	}
+}
 
 @mixin dh-focus() {
 	outline: 3px solid transparent;
@@ -45,304 +52,303 @@ $tablet: 40.0625em;
 	}
 }
 
- .datahub-header {
+@mixin tablet-padding() {
+	@media ( min-width: $tablet ) {
+		padding-left: 30px;
+		padding-right: 30px;
+	}
+}
+
+.datahub-header {
 	font-family: Arial,"Helvetica Neue",Helvetica,sans-serif;
 	line-height: 1.5;
 	background-color: black;
 	position: relative; //contain button
- }
 
-.datahub-header__logo-container {
+	&__logo {
+		font-size: 30px;
+		font-weight: bold;
+		display: inline-block;
+		padding-right: 2em;
 
-	color: white;
-	overflow: hidden;
-	font-weight: 700;
-	padding: 2px 15px;
-	box-sizing: content-box;
-	-moz-osx-font-smoothing: grayscale;
+		&__site-name {
+			@include govuk-visually-hidden;
+		}
 
-	a,
-	a:visited,
-	a:link {
-		color: white;
-		text-decoration: none;
-	}
-}
+		&__link {
+			@include dh-focus;
+		}
 
-.datahub-header__logo {
-	font-size: 30px;
-	font-weight: bold;
-	display: inline-block;
-	padding-right: 2em;
-}
-.datahub-header__logo__link {
-	@include dh-focus;
-}
-.datahub-header__logo__text {
-	-webkit-font-smoothing: initial; /* makes the font bolder */
-}
+		&__text {
+			-webkit-font-smoothing: initial; /* makes the font bolder */
+		}
+		
+		&__tag {
+			-webkit-font-smoothing: initial; /* makes the font bolder */
+			font-weight: 700;
+			font-size: 14px;
+			line-height: 1.25;
+			display: inline-block;
+			padding: 4px 8px 2px 8px;
+			outline: 2px solid transparent;
+			outline-offset: -2px;
+			color: white;
+			background-color: $govuk-blue;
+			letter-spacing: 1px;
+			text-decoration: none;
+			text-transform: uppercase;
+			position: relative;
+			top: -5px;
+		}
 
-.datahub-header__logo__tag {
-	-webkit-font-smoothing: initial; /* makes the font bolder */
-	font-weight: 700;
-	font-size: 14px;
-	line-height: 1.25;
-	display: inline-block;
-	padding: 4px 8px 2px 8px;
-	outline: 2px solid transparent;
-	outline-offset: -2px;
-	color: white;
-	background-color: $govuk-blue;
-	letter-spacing: 1px;
-	text-decoration: none;
-	text-transform: uppercase;
-	position: relative;
-	top: -5px;
-}
-
-.datahub-header__links {
-	display: block;
-	font-size: 16px;
-	list-style: none;
-	margin: 0;
-	padding: 0;
-	outline: 3px solid transparent;
-	font-weight: 700;
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
-}
-
-.datahub-header__links__item {
-	display: block;
-	border-bottom: 1px solid $govuk-grey-1;
-}
-
-.datahub-header__links__item:last-of-type {
-	border-bottom: 0;
-}
-
-.datahub-header__links__item__text {
-
-	display: inline-block;
-	padding: 5px 0;
-	width: 100%;
-
-	&.datahub-header__links__item__text--active {
-
-		color: $govuk-blue;
-
-		&:link,
-		&:visited {
-			color: $govuk-light-blue;
+		&-container {
+			color: white;
+			overflow: hidden;
+			font-weight: 700;
+			padding: 2px 15px;
+			box-sizing: content-box;
+			-moz-osx-font-smoothing: grayscale;
+			@include tablet-padding;
+		
+			a,
+			a:visited,
+			a:link {
+				color: white;
+				text-decoration: none;
+			}
 		}
 	}
 
-	@include dh-focus;
-}
+	&__menu-button {
+		font-weight: 400;
+		font-size: 14px;
+		line-height: 1.14286;
+		display: none;
+		position: absolute;
+		top: 20px;
+		right: 30px;
+		margin: 0;
+		padding: 0;
+		border: 0;
+		color: white;
+		background: 0 0;
+		@include dh-focus;
 
-.datahub-header__links__item a.datahub-header__links__item__text:hover {
-	text-decoration: underline;
-}
+		@media print {
+			font-family: sans-serif;
+			font-size: 14pt;
+			line-height: 1.2;
+		}
 
-.datahub-header__logo__site-name {
-	@include govuk-visually-hidden;
-}
+		@media ( min-width: $tablet ){
+			font-size:16px;
+			line-height: 1.25;
+			top: 15px;
+		}
 
-.datahub-header__navigation-wrapper {
-	background-color: $govuk-grey-3;
-	font-weight: 700;
-}
+		&:hover {
+			text-decoration: underline;
+		}
 
-.datahub-header__navigation-wrapper--sub {
-	background-color: $govuk-grey-4;
-	font-weight: normal;
-	border-bottom: 1px solid $govuk-grey-3;
-}
+		&::after {
+			display: inline-block;
+			width: 0;
+			height: 0;
+			border-style: solid;
+			border-color: transparent;
+			-webkit-clip-path: polygon( 0 0,50% 100%,100% 0 );
+			clip-path: polygon( 0 0,50% 100%,100% 0 );
+			border-width: 8.66px 5px 0 5px;
+			border-top-color: inherit;
+			content: "";
+			margin-left: 5px;
+		}
 
-.datahub-header__navigation {
-	margin: 0;
-	padding: 0;
-	list-style: none;
-	padding: 0 15px;
-	box-sizing: content-box;
-}
-
-.datahub-header__navigation__item {
-
-	display: block;
-	padding-right: 20px;
-
-	&:last-of-type {
-		padding-right: 0;
+		&--open::after {
+			display: inline-block;
+			width: 0;
+			height: 0;
+			border-style: solid;
+			border-color: transparent;
+			-webkit-clip-path: polygon( 50% 0,0 100%,100% 100% );
+			clip-path: polygon( 50% 0,0 100%,100% 100% );
+			border-width: 0 5px 8.66px 5px;
+			border-bottom-color: inherit;
+		}
 	}
-}
 
-.datahub-header__navigation__item__link {
+	&__links {
+		display: block;
+		font-size: 16px;
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		outline: 3px solid transparent;
+		font-weight: 700;
+		-webkit-font-smoothing: antialiased;
+		-moz-osx-font-smoothing: grayscale;
 
-	display: block;
-	padding: 5px 0;
-	margin: 0;
-	font-size: 16px;
-	line-height: 23px;
-	text-decoration: none;
-	color: $govuk-black;
+		@media ( min-width: $tablet ) {
+			float: right;
 
-	&:visited,
-	&:link {
-		color: $govuk-black;
+			&__item {
+				display: inline-block;
+				padding: 5px 10px;
+				border-bottom: 0;
+
+				&:last-of-type {
+					padding-right: 0;
+				}
+			}
+		}
+
+		&__item {
+			display: block;
+			border-bottom: 1px solid $govuk-grey-1;
+
+			:hover {
+				text-decoration: underline;
+			}
+
+			&:last-of-type {
+				border-bottom: 0;
+			}
+
+			&__text {
+				display: inline-block;
+				padding: 5px 0;
+				width: 100%;
+				@include dh-focus;
+
+				// Is this ever used?
+				&--active {
+					color: $govuk-blue;
+					&:link,
+					&:visited {
+						color: $govuk-light-blue;
+					}
+				}
+			}
+		}
 	}
 
-	&:hover {
-		color: $govuk-blue;
+	&__navigation {
+		margin: 0;
+		padding: 0;
+		list-style: none;
+		padding: 0 15px;
+		box-sizing: content-box;
+		@include tablet-padding;
+
+		&-wrapper {
+			background-color: $govuk-grey-3;
+			font-weight: 700;
+
+			&--sub {
+				background-color: $govuk-grey-4;
+				font-weight: normal;
+				border-bottom: 1px solid $govuk-grey-3;
+			}
+		}
+
+		&__item {
+			display: block;
+			padding-right: 20px;
+
+			@media ( min-width: $tablet ) {
+				display: inline-block;
+			}
+
+			&:last-of-type {
+				padding-right: 0;
+			}
+
+			&__link {
+				display: block;
+				padding: 5px 0;
+				margin: 0;
+				font-size: 16px;
+				line-height: 23px;
+				text-decoration: none;
+				color: $govuk-black;
+
+				@media ( min-width: $tablet ) {
+					display: inline-block;
+					padding: 8px 0;
+				}
+
+				&:visited,
+				&:link {
+					color: $govuk-black;
+				}
+
+				&:hover {
+					color: $govuk-blue;
+
+					@media ( min-width: $tablet ) {
+						color: $govuk-black;
+						padding-bottom: 3px;
+						border-bottom: 5px solid $govuk-blue;
+					}
+				}
+
+				&--active {
+					color: $govuk-blue;
+
+					@media ( min-width: $tablet ) {
+						padding-bottom: 3px;
+						border-bottom: 5px solid $govuk-blue;
+					}
+
+					&:visited,
+					&:link {
+						color: $govuk-blue;
+					}
+				}
+
+				@include dh-focus;
+			}
+		}
 	}
 
-	@include dh-focus;
-}
-
-.datahub-header__navigation__item__link--active {
-
-	color: $govuk-blue;
-
-	&:visited,
-	&:link {
-		color: $govuk-blue;
+	$grandparent: &;
+	&--max-width {
+		#{$grandparent} {
+			&__navigation,
+			&__logo-container {
+				max-width: 960px;
+				margin-left: auto;
+				margin-right: auto;
+			}
+		}
 	}
-}
-
-.datahub-header--max-width {
-
-	.datahub-header__logo-container,
-	.datahub-header__navigation {
-		max-width: 960px;
-		margin-left: auto;
-		margin-right: auto;
-	}
-}
-
-.datahub-header__menu-button {
-	font-weight: 400;
-	font-size: 14px;
-	line-height: 1.14286;
-	display: none;
-	position: absolute;
-	top: 20px;
-	right: 30px;
-	margin: 0;
-	padding: 0;
-	border: 0;
-	color: white;
-	background: 0 0;
-
-	@include dh-focus;
-}
-
-@media print {
-	.datahub-header__menu-button {
-		font-family: sans-serif;
-		font-size: 14pt;
-		line-height: 1.2;
-	}
-}
-
-.datahub-header__menu-button:hover {
-	text-decoration: underline;
-}
-
-.datahub-header__menu-button::after {
-	display: inline-block;
-	width: 0;
-	height: 0;
-	border-style: solid;
-	border-color: transparent;
-	-webkit-clip-path: polygon( 0 0,50% 100%,100% 0 );
-	clip-path: polygon( 0 0,50% 100%,100% 0 );
-	border-width: 8.66px 5px 0 5px;
-	border-top-color: inherit;
-	content: "";
-	margin-left: 5px;
-}
-
-.datahub-header__menu-button--open::after {
-	display: inline-block;
-	width: 0;
-	height: 0;
-	border-style: solid;
-	border-color: transparent;
-	-webkit-clip-path: polygon( 50% 0,0 100%,100% 100% );
-	clip-path: polygon( 50% 0,0 100%,100% 100% );
-	border-width: 0 5px 8.66px 5px;
-	border-bottom-color: inherit;
 }
 
 .js-datahub-header-enabled {
-	.datahub-header__menu-button {
-		display: block;
-		@media ( min-width: $tablet ){
-			display: none;
-		}
-	}
-
-	.datahub-header__navigation,
-	.datahub-header__links {
-		display: none;
-		@media ( min-width: $tablet ){
+	.datahub-header {
+		&__menu-button {
 			display: block;
+			@media ( min-width: $tablet ){
+				display: none;
+			}
+		}
+
+		&__navigation,
+		&__links {
+			display: none;
+			@media ( min-width: $tablet ){
+				display: block;
+			}
 		}
 	}
 
 	&.datahub-header--open {
-		.datahub-header__navigation,
-		.datahub-header__links {
-			display: block;
+		.datahub-header {
+			&__navigation,
+			&__links {
+				display: block;
+			}
 		}
 	}
  }
-
- @media ( min-width: $tablet ){
-	.datahub-header__menu-button {
-		font-size:16px;
-		line-height: 1.25;
-		top: 15px;
-	}
-
-	.datahub-header__links {
-		float: right;
-	}
-
-	.datahub-header__links__item {
-
-		display: inline-block;
-		padding: 5px 10px;
-		border-bottom: 0;
-
-		&:last-of-type {
-			padding-right: 0;
-		}
-	}
-
-	.datahub-header__logo-container,
-	.datahub-header__navigation {
-		padding-left: 30px;
-		padding-right: 30px;
-	}
-
-	.datahub-header__navigation__item {
-		display: inline-block;
-	}
-
-	.datahub-header__navigation__item__link {
-		display: inline-block;
-		padding: 8px 0;
-	}
-
-	.datahub-header__navigation__item__link:hover {
-		color: $govuk-black;
-		padding-bottom: 3px;
-		border-bottom: 5px solid $govuk-blue;
-	}
-
-	.datahub-header__navigation__item__link--active {
-		padding-bottom: 3px;
-		border-bottom: 5px solid $govuk-blue;
-	}
-}
+ 


### PR DESCRIPTION
This PR changes fixes the [accessibility issue of low contrast ratio of the focus state of links](https://uktrade.atlassian.net/jira/software/projects/CPS/boards/228?label=TEAM_CI&selectedIssue=CPS-128). It changes the appearance of focus state of all links from a yellow outline to a black text on a yellow background with black underline [as defined in the GDS](https://design-system.service.gov.uk/get-started/focus-states/).

Also, as part of this PR I have refactored the SCSS so that rules are nested.

## Before
<img width="999" alt="Screen Shot 2021-05-12 at 2 32 17 PM" src="https://user-images.githubusercontent.com/2333157/117983511-f1b57280-b32e-11eb-9de3-6bb40d9f15be.png">

## After
<img width="999" alt="Screen Shot 2021-05-12 at 2 31 03 PM" src="https://user-images.githubusercontent.com/2333157/117983514-f24e0900-b32e-11eb-8d42-76cb113c051f.png">

