### PR TITLE
Prevent apps to add outline to links

### DIFF
--- a/src/component/header.scss
+++ b/src/component/header.scss
@@ -78,6 +78,12 @@ $tablet: 40.0625em;
 	background-color: black;
 	position: relative; //contain button
 
+	// Prevent apps to add an outline to the header's links
+	a {
+		box-shadow: none !important;
+		outline: none !important;
+	}
+
 	&__logo {
 		font-size: 30px;
 		font-weight: bold;


### PR DESCRIPTION
This PR adds a CSS rule which prevents apps that are using the header as a dependency to add a focus outline to its links.

## Before

DataHub adds yellow outline to the header links:

<img width="730" alt="Screen Shot 2021-05-13 at 4 57 22 PM" src="https://user-images.githubusercontent.com/2333157/118152195-585c8e00-b40c-11eb-8444-a5367ce4784d.png">

## After
After the change the outline added by DataHub is rejected:

<img width="732" alt="Screen Shot 2021-05-13 at 4 57 06 PM" src="https://user-images.githubusercontent.com/2333157/118152200-598dbb00-b40c-11eb-987f-fb3aa184bf2b.png">
